### PR TITLE
Add .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+/.idea
+/example/**/build
+
+*.log


### PR DESCRIPTION
The current npm release is broken due to a missing .npmignore file.

I didn't think to add the .npmignore file, so npm did not publish the contents of /lib as that path is in .gitignore. My apologies

Edit: Just in case, remember to run `npm run build` before publishing :)