### PR TITLE
Use unresized image to calculate ratio of placeholder image

### DIFF
--- a/src/placeholder-loader.js
+++ b/src/placeholder-loader.js
@@ -66,10 +66,14 @@ function createPlaceholder(content, options) {
       return getColor(content, size.type);
     })
     .then((color) => {
+    
+      // Use the size of the unresized image to calculate the exact ratio
+      const originalContentSize = imageSize(content);
+    
       return {
         color,
         url: placeholderUrl,
-        ratio: (size.height / size.width),
+        ratio: (originalContentSize.height / originalContentSize.width),
       };
     });
 }


### PR DESCRIPTION
When using placeholders, the page may still jump slightly when the ratio has been calculated using the resized placeholder image instead of the original image. In my use case, this led to a size difference of several pixels and ugly artefacts.

E.g.

Image | Size | Ratio
------|------|-------
Original Image | 2255 x 2701 px | 1.1977827051
Placeholder Image | 20 x 24 px | 1.2

Displayed Image Width | Calculated Height using Original Image Ratio | Calculated Height using Placeholder Image Ratio
-|-----------------------|-----------------------
1200 px | 1437 px | 1440 px

This pull request should fix that by calculating the ratio using the original image.