### PR TITLE
Transform resource URL to include size

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -78,7 +78,7 @@ function buildSources(sizes, loaders, resource) {
     }
 
     const actualSize = size || DEFAULT_SIZE;
-    sources[actualSize] = createResizeRequest(actualSize, loaders, resource);
+    sources[actualSize] = createResizeRequest(actualSize, loaders, resource(size));
   });
 
   return sources;
@@ -159,7 +159,9 @@ srcSetLoader.pitch = function srcSetLoaderPitch(remainingRequest) {
 
   const [loaders, resource] = splitRemainingRequest(remainingRequest);
 
-  const sources = buildSources(sizes, loaders, resource);
+  const transformResource = loaderQuery.transformResource || ((resource, size) => resource + '?size=' + size)
+
+  const sources = buildSources(sizes, loaders, (size => transformResource(resource, size)));
 
   const srcSet = !lightweight
     ? `srcSet: ${stringifySrcSet(sources)},`

--- a/test/test.js
+++ b/test/test.js
@@ -178,17 +178,17 @@ describe('Resource Query', () => {
 
       return new Promise((resolve, reject) => {
         const imgTag = window.Image();
-        imgTag.onload = function onLoad() {
+        imgTag.addEventListener('load', function onLoad() {
           console.log(imgTag.naturalWidth);
           console.log(imgTag.naturalHeight);
 
           console.log(imgTag);
           resolve();
-        };
+        });
 
-        imgTag.onerror = function onError(e) {
+        imgTag.addEventListener('error', function onError(e) {
           reject(e);
-        };
+        });
 
         imgTag.src = img.placeholder.url;
       });

--- a/test/test.js
+++ b/test/test.js
@@ -178,17 +178,17 @@ describe('Resource Query', () => {
 
       return new Promise((resolve, reject) => {
         const imgTag = window.Image();
-        imgTag.addEventListener('load', function onLoad() {
+        imgTag.onload = function onLoad() {
           console.log(imgTag.naturalWidth);
           console.log(imgTag.naturalHeight);
 
           console.log(imgTag);
           resolve();
-        });
+        };
 
-        imgTag.addEventListener('error', function onError(e) {
+        imgTag.onerror = function onError(e) {
           reject(e);
-        });
+        };
 
         imgTag.src = img.placeholder.url;
       });


### PR DESCRIPTION
Quick go at a fix for #11 .

Adds new loader option `transformResource` for generating a unique resource URL for each resized image request. Generates unique keys in webpack manifest. Defaults to generating e.g. `filename.jpg?size=300w`.

I'm not in a huge rush for a merge so happy to do a bit of bikeshedding on variable names etc.