### PR TITLE
Build on prepare rather than prepublishOnly

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build": "babel src --out-dir lib --copy-files",
     "build:watch": "npm run build -- --watch",
     "test": "NODE_ENV=test mocha --compilers js:babel-core/register --reporter spec --check-leaks",
-    "prepublishOnly": "npm run build"
+    "prepare": "npm run build"
   },
   "keywords": [
     "webpack",


### PR DESCRIPTION
This ensures the package is built when installed via a git URL.