### PR TITLE
Don’t process with sharp if same width

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -19,7 +19,7 @@ export function resizeImage(content, width, height) {
 
   // dont scale up images, let the browser do that
   // and btw. wtf stop trying to fool me :P
-  if (source.width < width) {
+  if (source.width <= width) {
     return Promise.resolve(content);
   }
 


### PR DESCRIPTION
The original intention of the check was to skip upscaling, but skipping Sharp processing if a user requests an image of the original size would also be ideal, both from a perf perspective, and Sharp ruining some files if it unnecessarily touches them (such as animated GIFs—see https://github.com/lovell/sharp/issues/245).

I was able to successfully build in my project, so this seems to be working. This actually solves a really big problem for me (Sharp killing animated GIFs), but I’d love to know if this causes undue side effects I’m not considering.